### PR TITLE
Extend configuration with browser/size arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Goggles.each([:chrome, :firefox], [1080]) do |browser|
 end
 ```
 
-**TODO**
-
-Before the 1.0.0 release, these arguments will act as additonal browsers/sizes to script against. That way, the base configuration can be extended for particular script instances.
-
 #### Screenshots
 
 Your script blocks should include the `Watir::Browser#grab_screenshot` method, which has been patched onto the browser objects yielded to your blocks. Simply give the method a description argument and the screenshot will be saved to your configured directory.

--- a/features/goggles.feature
+++ b/features/goggles.feature
@@ -1,0 +1,23 @@
+Feature: Screenshot comparison
+  As a software professional
+  I want to automate the collection and comparison of screenshots on my application
+  So I can efficiently assess visual regression
+
+  Background:
+    Given I have configured Goggles with a valid directory
+    Given I have configured Goggles for browsers at 1080 width
+
+  Scenario: Compare screenshots in two browsers at one size
+    When I use the description "search-home" in my script
+    Then I have a file called "search-home_1080/chrome_firefox_diff.png"
+    And I have a file called "search-home_1080/chrome_firefox_data.txt"
+
+  Scenario: Extending a script with more browsers and sizes
+    When I extend configuration with arguments "phantomjs, 500"
+    And I use the description "homepage" in my script
+    Then I have a file called "homepage_1080/chrome_firefox_diff.png"
+    And I have a file called "homepage_1080/chrome_firefox_data.txt"
+    And I have a file called "homepage_1080/chrome_phantomjs_diff.png"
+    And I have a file called "homepage_1080/chrome_phantomjs_data.txt"
+    And I have a file called "homepage_1080/firefox_phantomjs_diff.png"
+    And I have a file called "homepage_1080/firefox_phantomjs_data.txt"

--- a/features/step_definitions/goggles_steps.rb
+++ b/features/step_definitions/goggles_steps.rb
@@ -1,0 +1,27 @@
+Given /^I have configured Goggles with a valid directory$/ do
+  @results = Pathname.new("./results").realdirpath.to_s 
+  Goggles.configure { |c| c.directory = @results }
+end
+
+Given /^I have configured Goggles for browsers at (\d+) width$/ do |width| 
+  Goggles.configure do |c|
+    c.browsers = [:chrome, :firefox]
+    c.sizes    = [width]
+  end
+end
+
+When /^I extend configuration with arguments "(.*)"$/ do |args|
+  @args = args.split(/,/).map(&:strip)
+end
+
+When /^I use the description "(.*)" in my script$/ do |desc|
+  Goggles.each(@args) do |browser|
+    browser.goto "http://google.com"
+    browser.grab_screenshot desc
+  end
+end
+
+Then /^I have a file called "(.*)"$/ do |file|
+  filepath = "#{@results}/#{file}"
+  File.exists? filepath
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,5 @@
+require "goggles"
+
+After do
+  FileUtils.rm_rf @results
+end

--- a/goggles.gemspec
+++ b/goggles.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "cucumber"
 
   spec.add_runtime_dependency "watir-webdriver"
   spec.add_runtime_dependency "image_size"

--- a/lib/goggles.rb
+++ b/lib/goggles.rb
@@ -9,13 +9,13 @@ module Goggles
     configuration.tap { |conf| yield conf }
   end
 
-  def each browsers = nil, sizes = nil, &block
-    instance_config = configuration.dup.tap do |c|
-      c.browsers << browsers unless browsers.nil?
-      c.sizes << sizes unless sizes.nil?
-    end
+  def each *args, &block
+    args.map!(&:to_s)
     
-    instance_config.browsers.product(instance_config.sizes).each do |browser, size|
+    sizes = configuration.sizes + args.grep(/\d+/).map(&:to_i)
+    browsers = configuration.browsers + args.grep(/[^\d+]/).map(&:to_sym)
+    
+    browsers.product(sizes).each do |browser, size|
       Iteration.new browser, size, configuration, &block 
     end
     

--- a/lib/goggles.rb
+++ b/lib/goggles.rb
@@ -9,8 +9,8 @@ module Goggles
     configuration.tap { |conf| yield conf }
   end
 
-  def each *args, &block
-    args.map!(&:to_s)
+  def each *instance, &block
+    args = instance.flatten.map(&:to_s)
     
     sizes = configuration.sizes + args.grep(/\d+/).map(&:to_i)
     browsers = configuration.browsers + args.grep(/[^\d+]/).map(&:to_sym)

--- a/lib/goggles.rb
+++ b/lib/goggles.rb
@@ -10,10 +10,12 @@ module Goggles
   end
 
   def each browsers = nil, sizes = nil, &block
-    browsers ||= configuration.browsers
-    sizes    ||= configuration.sizes
+    instance_config = configuration.dup.tap do |c|
+      c.browsers << browsers unless browsers.nil?
+      c.sizes << sizes unless sizes.nil?
+    end
     
-    browsers.product(sizes).each do |browser, size|
+    instance_config.browsers.product(instance_config.sizes).each do |browser, size|
       Iteration.new browser, size, configuration, &block 
     end
     

--- a/spec/goggles_spec.rb
+++ b/spec/goggles_spec.rb
@@ -34,9 +34,21 @@ describe Goggles do
       Goggles.each { "foo" }
     end
 
-    it "accepts non-configured browser and size arguments" do
-      expect(Goggles::Iteration).to receive(:new).with(:bar, 300, config)
-      Goggles.each([:bar], [300]) { "foo" }
+    context "when given a non-configured browser" do
+      it "iterates with configured and argument browsers" do
+        expect(Goggles::Iteration).to receive(:new).with(:foo, 500, config)
+        expect(Goggles::Iteration).to receive(:new).with(:bar, 500, config)
+        Goggles.each(:bar) { "foo" }
+      end
+
+      context "and given a non-configured size" do
+        it "iterates over each configured and given combination" do
+          [:foo, :bar].product([500, 1000]).each do |b, s|
+            expect(Goggles::Iteration).to receive(:new).with(b, s, config)
+          end
+          Goggles.each(:bar, 1000) { "foo" }
+        end
+      end
     end
     
     it "returns a comparison object" do

--- a/spec/goggles_spec.rb
+++ b/spec/goggles_spec.rb
@@ -51,7 +51,7 @@ describe Goggles do
     end
 
     context "when given multiple browser and size arguments" do
-      it "extends the configuration with the correct arguments" do
+      it "extends the configuration with correctly" do
         [:foo, :bar, :baz].product([500, 1000, 250]).each do |b, s|
           expect(Goggles::Iteration).to receive(:new).with(b, s, config)
         end
@@ -65,6 +65,24 @@ describe Goggles do
           end
           Goggles.each(1000, :bar, :baz, 250) { "foo" }
         end
+      end
+    end
+
+    context "when given arguments in arrays" do
+      it "extends the configuration correctly" do
+        [:foo, :bar, :baz].product([500, 1000, 250]).each do |b, s|
+          expect(Goggles::Iteration).to receive(:new).with(b, s, config)
+        end
+        Goggles.each([:bar, :baz], [250, 1000]) { "foo" }
+      end
+    end
+
+    context "when given arguments of various classes" do
+      it "extends the configuration correctly" do
+        [:foo, :bar, :baz].product([500, 1000, 250]).each do |b, s|
+          expect(Goggles::Iteration).to receive(:new).with(b, s, config)
+        end
+        Goggles.each([:bar, "baz"], 250, "1000") { "foo" }
       end
     end
     

--- a/spec/goggles_spec.rb
+++ b/spec/goggles_spec.rb
@@ -34,19 +34,36 @@ describe Goggles do
       Goggles.each { "foo" }
     end
 
-    context "when given a non-configured browser" do
-      it "iterates with configured and argument browsers" do
+    context "when given a browser argument" do
+      it "extends the configured browser list with the given browser" do
         expect(Goggles::Iteration).to receive(:new).with(:foo, 500, config)
         expect(Goggles::Iteration).to receive(:new).with(:bar, 500, config)
         Goggles.each(:bar) { "foo" }
       end
+    end
 
-      context "and given a non-configured size" do
-        it "iterates over each configured and given combination" do
-          [:foo, :bar].product([500, 1000]).each do |b, s|
+    context "when given a size argument" do
+      it "extends the configured size list with the given size" do
+        expect(Goggles::Iteration).to receive(:new).with(:foo, 500, config)
+        expect(Goggles::Iteration).to receive(:new).with(:foo, 250, config)
+        Goggles.each(250) { "foo" }
+      end      
+    end
+
+    context "when given multiple browser and size arguments" do
+      it "extends the configuration with the correct arguments" do
+        [:foo, :bar, :baz].product([500, 1000, 250]).each do |b, s|
+          expect(Goggles::Iteration).to receive(:new).with(b, s, config)
+        end
+        Goggles.each(:bar, :baz, 1000, 250) { "foo" }
+      end
+
+      context "in no particular order" do
+        it "extends the configuration with the correct arguments" do
+          [:foo, :bar, :baz].product([500, 1000, 250]).each do |b, s|
             expect(Goggles::Iteration).to receive(:new).with(b, s, config)
           end
-          Goggles.each(:bar, 1000) { "foo" }
+          Goggles.each(1000, :bar, :baz, 250) { "foo" }
         end
       end
     end


### PR DESCRIPTION
- `Goggles.each` takes Array, String, Symbol, and Fixnum arguments.
- Arguments passed to `Goggles.each` extend configured settings instead of overwriting them.
- Add e2e Cucumber tests.
